### PR TITLE
Fix logger generic types

### DIFF
--- a/Controllers/ControllerQuery.cs
+++ b/Controllers/ControllerQuery.cs
@@ -14,10 +14,10 @@ namespace AzureSamples.AzureSQL.Controllers
 {
     public class ControllerQuery : ControllerBase
     {
-        private readonly ILogger<CustomersController> _logger;
+        private readonly ILogger<ControllerQuery> _logger;
         private readonly IConfiguration _config;
 
-        public ControllerQuery(IConfiguration config, ILogger<CustomersController> logger)
+        public ControllerQuery(IConfiguration config, ILogger<ControllerQuery> logger)
         {
             _logger = logger;
             _config = config;

--- a/Controllers/CustomerController.cs
+++ b/Controllers/CustomerController.cs
@@ -13,7 +13,7 @@ namespace AzureSamples.AzureSQL.Controllers
     [Route("[controller]")]
     public class CustomerController : ControllerQuery
     {
-        public CustomerController(IConfiguration config, ILogger<CustomersController> logger):
+        public CustomerController(IConfiguration config, ILogger<CustomerController> logger):
             base(config, logger) {}
 
         [HttpGet("{customerId}")]


### PR DESCRIPTION
## Summary
- use `ILogger<ControllerQuery>` in `ControllerQuery`
- accept `ILogger<CustomerController>` in `CustomerController`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427271caec832daac5f435893ebf4a